### PR TITLE
Release the scan for Log4Shell (CVE-2021-44228)

### DIFF
--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -2,8 +2,8 @@ Uuid: 3123d5b5f25c4128894d97ea1acc4976
 ExtensionType: 2
 Name: Active Scan++
 RepoName: active-scan-plus-plus
-ScreenVersion: 1.0.22
-SerialVersion: 23
+ScreenVersion: 1.0.23
+SerialVersion: 24
 MinPlatformVersion: 0
 ProOnly: True
 Author: James Kettle


### PR DESCRIPTION
I have to admit, that I am not sure what the proper steps are to release a new version in der Burp Store.

However, as https://github.com/albinowax/ActiveScanPlusPlus seems not be updated anymore and here is not option to open tickets, I decided to raise the awareness, that the check, that was added on Friday, is not released yet.