### PR TITLE
Bump version to reflect Changelog

### DIFF
--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -2,8 +2,8 @@ Uuid: 3123d5b5f25c4128894d97ea1acc4976
 ExtensionType: 2
 Name: Active Scan++
 RepoName: active-scan-plus-plus
-ScreenVersion: 1.0.22
-SerialVersion: 23
+ScreenVersion: 1.0.23
+SerialVersion: 24
 MinPlatformVersion: 0
 ProOnly: True
 Author: James Kettle


### PR DESCRIPTION
The new version with log4j check included has been recorded in the changelog but the version in bapp manifest was not bumped.