### PR TITLE
Add Google API Key Gemini privilege escalation check

### DIFF
--- a/src/burp/BurpExtender.java
+++ b/src/burp/BurpExtender.java
@@ -25,7 +25,7 @@ public class BurpExtender implements IBurpExtender, IExtensionStateListener, Bur
         if (!Utilities.montoyaApi.burpSuite().version().edition().equals(BurpSuiteEdition.ENTERPRISE_EDITION)) {
             BulkUtilities.registerContextMenu();
         }
-        GoogleApiKeySettingsPanel.register(api);
+        ExtensionSettingsPanel.register(api);
         // api.http().registerHttpHandler(new Tester());
         // api.userInterface().registerContextMenuItemsProvider(new OfferHostnameOverride());
     }

--- a/src/burp/BurpExtender.java
+++ b/src/burp/BurpExtender.java
@@ -15,8 +15,6 @@ public class BurpExtender implements IBurpExtender, IExtensionStateListener, Bur
     private static final String version = "2.0.10";
     public boolean unloaded = false;
     static ConcurrentHashMap<String, Boolean> hostsToSkip = new ConcurrentHashMap<>();
-    static volatile Object settingsPanel = null;
-    static volatile boolean settingsPanelAvailable = false;
 
     @Override
     public void initialize(MontoyaApi api) {

--- a/src/burp/BurpExtender.java
+++ b/src/burp/BurpExtender.java
@@ -13,7 +13,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 public class BurpExtender implements IBurpExtender, IExtensionStateListener, BurpExtension {
     private static final String name = "ActiveScan++";
-    private static final String version = "2.0.9";
+    private static final String version = "2.0.10";
     public boolean unloaded = false;
     static ConcurrentHashMap<String, Boolean> hostsToSkip = new ConcurrentHashMap<>();
     static final AtomicBoolean verifyGeminiAccess = new AtomicBoolean(false);

--- a/src/burp/BurpExtender.java
+++ b/src/burp/BurpExtender.java
@@ -9,12 +9,15 @@ import java.nio.charset.Charset;
 
 import java.util.HashMap;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class BurpExtender implements IBurpExtender, IExtensionStateListener, BurpExtension {
     private static final String name = "ActiveScan++";
     private static final String version = "2.0.9";
     public boolean unloaded = false;
     static ConcurrentHashMap<String, Boolean> hostsToSkip = new ConcurrentHashMap<>();
+    static final AtomicBoolean verifyGeminiAccess = new AtomicBoolean(false);
+    static volatile boolean settingsPanelAvailable = false;
 
     @Override
     public void initialize(MontoyaApi api) {
@@ -22,6 +25,7 @@ public class BurpExtender implements IBurpExtender, IExtensionStateListener, Bur
         if (!Utilities.montoyaApi.burpSuite().version().edition().equals(BurpSuiteEdition.ENTERPRISE_EDITION)) {
             BulkUtilities.registerContextMenu();
         }
+        GoogleApiKeySettingsPanel.register(api);
         // api.http().registerHttpHandler(new Tester());
         // api.userInterface().registerContextMenuItemsProvider(new OfferHostnameOverride());
     }

--- a/src/burp/BurpExtender.java
+++ b/src/burp/BurpExtender.java
@@ -24,8 +24,8 @@ public class BurpExtender implements IBurpExtender, IExtensionStateListener, Bur
         Utilities.montoyaApi = api;
         if (!Utilities.montoyaApi.burpSuite().version().edition().equals(BurpSuiteEdition.ENTERPRISE_EDITION)) {
             BulkUtilities.registerContextMenu();
+            ExtensionSettingsPanel.register(api);
         }
-        ExtensionSettingsPanel.register(api);
         // api.http().registerHttpHandler(new Tester());
         // api.userInterface().registerContextMenuItemsProvider(new OfferHostnameOverride());
     }

--- a/src/burp/BurpExtender.java
+++ b/src/burp/BurpExtender.java
@@ -43,6 +43,7 @@ public class BurpExtender implements IBurpExtender, IExtensionStateListener, Bur
         Utilities.callbacks.registerScannerCheck(new Struts201712611Scan("Struts 2017-12611 Scan"));
         Utilities.callbacks.registerScannerCheck(new SuspectTransform("Suspect Transform"));
         Utilities.callbacks.registerScannerCheck(new XMLScan("XML security"));
+        Utilities.callbacks.registerScannerCheck(new GoogleApiKeyScan("Google API Key Scan"));
         new KitchenSink("Launch all scans");
 
         new BulkScanLauncher(BulkScan.scans);

--- a/src/burp/BurpExtender.java
+++ b/src/burp/BurpExtender.java
@@ -9,14 +9,13 @@ import java.nio.charset.Charset;
 
 import java.util.HashMap;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 public class BurpExtender implements IBurpExtender, IExtensionStateListener, BurpExtension {
     private static final String name = "ActiveScan++";
     private static final String version = "2.0.10";
     public boolean unloaded = false;
     static ConcurrentHashMap<String, Boolean> hostsToSkip = new ConcurrentHashMap<>();
-    static final AtomicBoolean verifyGeminiAccess = new AtomicBoolean(false);
+    static volatile Object settingsPanel = null;
     static volatile boolean settingsPanelAvailable = false;
 
     @Override

--- a/src/burp/ExtensionSettingsPanel.java
+++ b/src/burp/ExtensionSettingsPanel.java
@@ -7,9 +7,10 @@ import java.util.Set;
 
 class ExtensionSettingsPanel {
 
-    private static final int BUILDER_API_YEAR = 2025;
-    private static final int BUILDER_API_MAJOR = 6;
+    static final String VERIFY_GEMINI_KEY = "Verify Gemini API access (sends requests to Google)";
     private static final String LEGACY_PERSISTENCE_KEY = "google-api-key.verify-gemini-access";
+    private static final int MIN_SETTINGS_API_YEAR = 2025;
+    private static final int MIN_SETTINGS_API_MAJOR = 6;
 
     private static volatile Object settingsPanel = null;
     private static volatile boolean legacyVerifyGeminiAccess = false;
@@ -17,8 +18,6 @@ class ExtensionSettingsPanel {
     static boolean isPanelAvailable() {
         return settingsPanel != null;
     }
-
-    static final String VERIFY_GEMINI_KEY = "Verify Gemini API access (sends requests to Google)";
 
     static void register(MontoyaApi api) {
         if (supportsBuilderApi(api)) {
@@ -47,7 +46,7 @@ class ExtensionSettingsPanel {
             String[] parts = api.burpSuite().version().name().split("\\.");
             int year = Integer.parseInt(parts[0]);
             int major = Integer.parseInt(parts[1]);
-            return year > BUILDER_API_YEAR || (year == BUILDER_API_YEAR && major >= BUILDER_API_MAJOR);
+            return year > MIN_SETTINGS_API_YEAR || (year == MIN_SETTINGS_API_YEAR && major >= MIN_SETTINGS_API_MAJOR);
         } catch (Exception e) {
             Utilities.err("Could not parse Burp version, assuming legacy: " + e.getMessage());
             return false;
@@ -102,20 +101,21 @@ class ExtensionSettingsPanel {
 
     private static class ReflectiveBuilder {
         private final Class<?> cls;
-        private Object obj;
+        private Object builderInstance;
 
-        ReflectiveBuilder(Class<?> cls, Object obj) {
+        ReflectiveBuilder(Class<?> cls, Object builderInstance) {
             this.cls = cls;
-            this.obj = obj;
+            this.builderInstance = builderInstance;
         }
 
         ReflectiveBuilder with(String method, Class<?> paramType, Object arg) throws Exception {
-            obj = cls.getMethod(method, paramType).invoke(obj, arg);
+            builderInstance = cls.getMethod(method, paramType).invoke(builderInstance, arg);
             return this;
         }
 
         Object build() throws Exception {
-            return cls.getMethod("build").invoke(obj);
+            return cls.getMethod("build").invoke(builderInstance);
         }
     }
 }
+

--- a/src/burp/ExtensionSettingsPanel.java
+++ b/src/burp/ExtensionSettingsPanel.java
@@ -39,9 +39,8 @@ class ExtensionSettingsPanel {
 
     private static boolean supportsBuilderApi(MontoyaApi api) {
         try {
-            String[] parts = api.burpSuite().version().name().split("\\.");
-            int year = Integer.parseInt(parts[0]);
-            int major = Integer.parseInt(parts[1]);
+            int year = Integer.parseInt(api.burpSuite().version().major());
+            int major = Integer.parseInt(api.burpSuite().version().minor());
             return year > MIN_SETTINGS_API_YEAR || (year == MIN_SETTINGS_API_YEAR && major >= MIN_SETTINGS_API_MAJOR);
         } catch (Exception e) {
             Utilities.err("Could not parse Burp version, assuming legacy: " + e.getMessage());

--- a/src/burp/ExtensionSettingsPanel.java
+++ b/src/burp/ExtensionSettingsPanel.java
@@ -2,90 +2,75 @@ package burp;
 
 import burp.api.montoya.MontoyaApi;
 
-import javax.swing.*;
-import java.awt.*;
-import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.Set;
 
 class ExtensionSettingsPanel {
 
-    private static final String VERIFY_GEMINI_KEY = "google-api-key.verify-gemini-access";
-
-    private final JPanel panel;
-
-    ExtensionSettingsPanel(MontoyaApi api) {
-        panel = new JPanel();
-        panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
-        panel.setBorder(BorderFactory.createEmptyBorder(20, 20, 20, 20));
-
-        addGoogleApiKeySection(api);
-    }
-
-    private void addGoogleApiKeySection(MontoyaApi api) {
-        boolean savedValue = "true".equals(api.persistence().extensionData().getString(VERIFY_GEMINI_KEY));
-        BurpExtender.verifyGeminiAccess.set(savedValue);
-
-        JCheckBox verifyCheckbox = new JCheckBox("Verify Gemini API access (sends requests to Google)");
-        verifyCheckbox.setIconTextGap(8);
-        verifyCheckbox.setSelected(savedValue);
-        verifyCheckbox.addActionListener(e -> {
-            boolean selected = verifyCheckbox.isSelected();
-            BurpExtender.verifyGeminiAccess.set(selected);
-            api.persistence().extensionData().setString(VERIFY_GEMINI_KEY, String.valueOf(selected));
-        });
-
-        Font defaultFont = UIManager.getFont("Label.font");
-        if (defaultFont == null) {
-            defaultFont = new JLabel().getFont();
-        }
-        float defaultSize = defaultFont.getSize();
-
-        JLabel heading = new JLabel("Google API Key Scan");
-        heading.setFont(defaultFont.deriveFont(Font.BOLD, (int) (1.2f * defaultSize)));
-        heading.setAlignmentX(Component.LEFT_ALIGNMENT);
-        heading.setBorder(BorderFactory.createEmptyBorder(0, 0, 5, 0));
-
-        JTextArea description = new JTextArea(
-                "When enabled, detected API keys are checked against Google's Gemini API " +
-                "endpoints to confirm access. This upgrades findings from Information to " +
-                "Medium/High severity.");
-        description.setEditable(false);
-        description.setFocusable(false);
-        description.setLineWrap(true);
-        description.setWrapStyleWord(true);
-        description.setOpaque(false);
-        description.setFont(defaultFont);
-        description.setAlignmentX(Component.LEFT_ALIGNMENT);
-        description.setBorder(BorderFactory.createEmptyBorder(0, 0, 10, 0));
-
-        verifyCheckbox.setAlignmentX(Component.LEFT_ALIGNMENT);
-
-        panel.add(heading);
-        panel.add(description);
-        panel.add(verifyCheckbox);
-    }
+    static final String VERIFY_GEMINI_KEY = "Verify Gemini API access (sends requests to Google)";
 
     static void register(MontoyaApi api) {
         try {
-            ExtensionSettingsPanel settingsPanel = new ExtensionSettingsPanel(api);
-            Object proxy = java.lang.reflect.Proxy.newProxyInstance(
-                    api.getClass().getClassLoader(),
-                    new Class[]{Class.forName("burp.api.montoya.ui.settings.SettingsPanel")},
-                    (p, method, args) -> {
-                        if ("uiComponent".equals(method.getName())) {
-                            return settingsPanel.panel;
-                        }
-                        if ("keywords".equals(method.getName())) {
-                            return java.util.Set.of("activescan", "active", "scan", "google", "api", "key", "gemini");
-                        }
-                        return null;
-                    }
-            );
-            Method registerMethod = api.userInterface().getClass().getMethod(
-                    "registerSettingsPanel", Class.forName("burp.api.montoya.ui.settings.SettingsPanel"));
-            registerMethod.invoke(api.userInterface(), proxy);
+            ClassLoader cl = api.getClass().getClassLoader();
+            Class<?> builderClass = Class.forName("burp.api.montoya.ui.settings.SettingsPanelBuilder", true, cl);
+            Class<?> settingClass = Class.forName("burp.api.montoya.ui.settings.SettingsPanelSetting", true, cl);
+            Class<?> persistenceClass = Class.forName("burp.api.montoya.ui.settings.SettingsPanelPersistence", true, cl);
+
+            Object setting = settingClass
+                    .getMethod("booleanSetting", String.class, boolean.class)
+                    .invoke(null, VERIFY_GEMINI_KEY, false);
+
+            @SuppressWarnings("unchecked")
+            Object persistence = Enum.valueOf((Class<Enum>) persistenceClass, "USER_SETTINGS");
+
+            Object panel = new ReflectiveBuilder(builderClass, builderClass.getMethod("settingsPanel").invoke(null))
+                    .with("withTitle", String.class, "Google API Key Scan")
+                    .with("withDescription", String.class,
+                            "When enabled, detected API keys are checked against Google's Gemini API " +
+                            "endpoints to confirm access. This upgrades findings from Information to " +
+                            "Medium/High severity.")
+                    .with("withSetting", settingClass, setting)
+                    .with("withPersistence", persistenceClass, persistence)
+                    .with("withKeywords", Collection.class, Set.of("activescan", "active", "scan", "google", "api", "key", "gemini"))
+                    .build();
+
+            api.userInterface().getClass()
+                    .getMethod("registerSettingsPanel", Class.forName("burp.api.montoya.ui.settings.SettingsPanel", true, cl))
+                    .invoke(api.userInterface(), panel);
+
+            BurpExtender.settingsPanel = panel;
             BurpExtender.settingsPanelAvailable = true;
         } catch (Exception e) {
-            Utilities.err("Could not register settings panel (requires Burp 2025.5+): " + e.getMessage());
+            Utilities.err("Could not register settings panel (requires Burp 2025.6+): " + e.getMessage());
+        }
+    }
+
+    static boolean getVerifyGeminiAccess() {
+        try {
+            return (Boolean) BurpExtender.settingsPanel.getClass()
+                    .getMethod("getBoolean", String.class)
+                    .invoke(BurpExtender.settingsPanel, VERIFY_GEMINI_KEY);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private static class ReflectiveBuilder {
+        private final Class<?> cls;
+        private Object obj;
+
+        ReflectiveBuilder(Class<?> cls, Object obj) {
+            this.cls = cls;
+            this.obj = obj;
+        }
+
+        ReflectiveBuilder with(String method, Class<?> paramType, Object arg) throws Exception {
+            obj = cls.getMethod(method, paramType).invoke(obj, arg);
+            return this;
+        }
+
+        Object build() throws Exception {
+            return cls.getMethod("build").invoke(obj);
         }
     }
 }

--- a/src/burp/ExtensionSettingsPanel.java
+++ b/src/burp/ExtensionSettingsPanel.java
@@ -49,6 +49,7 @@ class ExtensionSettingsPanel {
             int major = Integer.parseInt(parts[1]);
             return year > BUILDER_API_YEAR || (year == BUILDER_API_YEAR && major >= BUILDER_API_MAJOR);
         } catch (Exception e) {
+            Utilities.err("Could not parse Burp version, assuming legacy: " + e.getMessage());
             return false;
         }
     }
@@ -91,7 +92,9 @@ class ExtensionSettingsPanel {
     private static void loadLegacySetting(MontoyaApi api) {
         try {
             String value = api.persistence().extensionData().getString(LEGACY_PERSISTENCE_KEY);
-            legacyVerifyGeminiAccess = Boolean.parseBoolean(value);
+            if (value != null) {
+                legacyVerifyGeminiAccess = Boolean.parseBoolean(value);
+            }
         } catch (Exception e) {
             Utilities.err("Failed to load legacy Gemini verify setting: " + e.getMessage());
         }

--- a/src/burp/ExtensionSettingsPanel.java
+++ b/src/burp/ExtensionSettingsPanel.java
@@ -7,6 +7,12 @@ import java.util.Set;
 
 class ExtensionSettingsPanel {
 
+    private static volatile Object settingsPanel = null;
+
+    static boolean isPanelAvailable() {
+        return settingsPanel != null;
+    }
+
     static final String VERIFY_GEMINI_KEY = "Verify Gemini API access (sends requests to Google)";
 
     static void register(MontoyaApi api) {
@@ -38,8 +44,7 @@ class ExtensionSettingsPanel {
                     .getMethod("registerSettingsPanel", Class.forName("burp.api.montoya.ui.settings.SettingsPanel", true, cl))
                     .invoke(api.userInterface(), panel);
 
-            BurpExtender.settingsPanel = panel;
-            BurpExtender.settingsPanelAvailable = true;
+            settingsPanel = panel;
         } catch (Exception e) {
             Utilities.err("Could not register settings panel (requires Burp 2025.6+): " + e.getMessage());
         }
@@ -47,9 +52,9 @@ class ExtensionSettingsPanel {
 
     static boolean getVerifyGeminiAccess() {
         try {
-            return (Boolean) BurpExtender.settingsPanel.getClass()
+            return (Boolean) settingsPanel.getClass()
                     .getMethod("getBoolean", String.class)
-                    .invoke(BurpExtender.settingsPanel, VERIFY_GEMINI_KEY);
+                    .invoke(settingsPanel, VERIFY_GEMINI_KEY);
         } catch (Exception e) {
             return false;
         }

--- a/src/burp/ExtensionSettingsPanel.java
+++ b/src/burp/ExtensionSettingsPanel.java
@@ -8,12 +8,10 @@ import java.util.Set;
 class ExtensionSettingsPanel {
 
     static final String VERIFY_GEMINI_KEY = "Verify Gemini API access (sends requests to Google)";
-    private static final String LEGACY_PERSISTENCE_KEY = "google-api-key.verify-gemini-access";
     private static final int MIN_SETTINGS_API_YEAR = 2025;
     private static final int MIN_SETTINGS_API_MAJOR = 6;
 
     private static volatile Object settingsPanel = null;
-    private static volatile boolean legacyVerifyGeminiAccess = false;
 
     static boolean isPanelAvailable() {
         return settingsPanel != null;
@@ -22,14 +20,12 @@ class ExtensionSettingsPanel {
     static void register(MontoyaApi api) {
         if (supportsBuilderApi(api)) {
             registerBuilderPanel(api);
-        } else {
-            loadLegacySetting(api);
         }
     }
 
     static boolean getVerifyGeminiAccess() {
         if (settingsPanel == null) {
-            return legacyVerifyGeminiAccess;
+            return false;
         }
         try {
             return (Boolean) settingsPanel.getClass()
@@ -85,17 +81,6 @@ class ExtensionSettingsPanel {
             settingsPanel = panel;
         } catch (Exception e) {
             Utilities.err("Could not register settings panel (requires Burp 2025.6+): " + e.getMessage());
-        }
-    }
-
-    private static void loadLegacySetting(MontoyaApi api) {
-        try {
-            String value = api.persistence().extensionData().getString(LEGACY_PERSISTENCE_KEY);
-            if (value != null) {
-                legacyVerifyGeminiAccess = Boolean.parseBoolean(value);
-            }
-        } catch (Exception e) {
-            Utilities.err("Failed to load legacy Gemini verify setting: " + e.getMessage());
         }
     }
 

--- a/src/burp/ExtensionSettingsPanel.java
+++ b/src/burp/ExtensionSettingsPanel.java
@@ -51,11 +51,15 @@ class ExtensionSettingsPanel {
     }
 
     static boolean getVerifyGeminiAccess() {
+        if (settingsPanel == null) {
+            return false;
+        }
         try {
             return (Boolean) settingsPanel.getClass()
                     .getMethod("getBoolean", String.class)
                     .invoke(settingsPanel, VERIFY_GEMINI_KEY);
         } catch (Exception e) {
+            Utilities.err("Failed to read Gemini verify setting: " + e.getMessage());
             return false;
         }
     }

--- a/src/burp/ExtensionSettingsPanel.java
+++ b/src/burp/ExtensionSettingsPanel.java
@@ -7,7 +7,12 @@ import java.util.Set;
 
 class ExtensionSettingsPanel {
 
+    private static final int BUILDER_API_YEAR = 2025;
+    private static final int BUILDER_API_MAJOR = 6;
+    private static final String LEGACY_PERSISTENCE_KEY = "google-api-key.verify-gemini-access";
+
     private static volatile Object settingsPanel = null;
+    private static volatile boolean legacyVerifyGeminiAccess = false;
 
     static boolean isPanelAvailable() {
         return settingsPanel != null;
@@ -16,6 +21,39 @@ class ExtensionSettingsPanel {
     static final String VERIFY_GEMINI_KEY = "Verify Gemini API access (sends requests to Google)";
 
     static void register(MontoyaApi api) {
+        if (supportsBuilderApi(api)) {
+            registerBuilderPanel(api);
+        } else {
+            loadLegacySetting(api);
+        }
+    }
+
+    static boolean getVerifyGeminiAccess() {
+        if (settingsPanel == null) {
+            return legacyVerifyGeminiAccess;
+        }
+        try {
+            return (Boolean) settingsPanel.getClass()
+                    .getMethod("getBoolean", String.class)
+                    .invoke(settingsPanel, VERIFY_GEMINI_KEY);
+        } catch (Exception e) {
+            Utilities.err("Failed to read Gemini verify setting: " + e.getMessage());
+            return false;
+        }
+    }
+
+    private static boolean supportsBuilderApi(MontoyaApi api) {
+        try {
+            String[] parts = api.burpSuite().version().name().split("\\.");
+            int year = Integer.parseInt(parts[0]);
+            int major = Integer.parseInt(parts[1]);
+            return year > BUILDER_API_YEAR || (year == BUILDER_API_YEAR && major >= BUILDER_API_MAJOR);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private static void registerBuilderPanel(MontoyaApi api) {
         try {
             ClassLoader cl = api.getClass().getClassLoader();
             Class<?> builderClass = Class.forName("burp.api.montoya.ui.settings.SettingsPanelBuilder", true, cl);
@@ -50,17 +88,12 @@ class ExtensionSettingsPanel {
         }
     }
 
-    static boolean getVerifyGeminiAccess() {
-        if (settingsPanel == null) {
-            return false;
-        }
+    private static void loadLegacySetting(MontoyaApi api) {
         try {
-            return (Boolean) settingsPanel.getClass()
-                    .getMethod("getBoolean", String.class)
-                    .invoke(settingsPanel, VERIFY_GEMINI_KEY);
+            String value = api.persistence().extensionData().getString(LEGACY_PERSISTENCE_KEY);
+            legacyVerifyGeminiAccess = Boolean.parseBoolean(value);
         } catch (Exception e) {
-            Utilities.err("Failed to read Gemini verify setting: " + e.getMessage());
-            return false;
+            Utilities.err("Failed to load legacy Gemini verify setting: " + e.getMessage());
         }
     }
 

--- a/src/burp/ExtensionSettingsPanel.java
+++ b/src/burp/ExtensionSettingsPanel.java
@@ -6,14 +6,22 @@ import javax.swing.*;
 import java.awt.*;
 import java.lang.reflect.Method;
 
-class GoogleApiKeySettingsPanel {
+class ExtensionSettingsPanel {
 
-    private static final String PERSISTENCE_KEY = "google-api-key.verify-gemini-access";
+    private static final String VERIFY_GEMINI_KEY = "google-api-key.verify-gemini-access";
 
     private final JPanel panel;
 
-    GoogleApiKeySettingsPanel(MontoyaApi api) {
-        boolean savedValue = "true".equals(api.persistence().extensionData().getString(PERSISTENCE_KEY));
+    ExtensionSettingsPanel(MontoyaApi api) {
+        panel = new JPanel();
+        panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
+        panel.setBorder(BorderFactory.createEmptyBorder(20, 20, 20, 20));
+
+        addGoogleApiKeySection(api);
+    }
+
+    private void addGoogleApiKeySection(MontoyaApi api) {
+        boolean savedValue = "true".equals(api.persistence().extensionData().getString(VERIFY_GEMINI_KEY));
         BurpExtender.verifyGeminiAccess.set(savedValue);
 
         JCheckBox verifyCheckbox = new JCheckBox("Verify Gemini API access (sends requests to Google)");
@@ -22,7 +30,7 @@ class GoogleApiKeySettingsPanel {
         verifyCheckbox.addActionListener(e -> {
             boolean selected = verifyCheckbox.isSelected();
             BurpExtender.verifyGeminiAccess.set(selected);
-            api.persistence().extensionData().setString(PERSISTENCE_KEY, String.valueOf(selected));
+            api.persistence().extensionData().setString(VERIFY_GEMINI_KEY, String.valueOf(selected));
         });
 
         Font defaultFont = UIManager.getFont("Label.font");
@@ -51,9 +59,6 @@ class GoogleApiKeySettingsPanel {
 
         verifyCheckbox.setAlignmentX(Component.LEFT_ALIGNMENT);
 
-        panel = new JPanel();
-        panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
-        panel.setBorder(BorderFactory.createEmptyBorder(20, 20, 20, 20));
         panel.add(heading);
         panel.add(description);
         panel.add(verifyCheckbox);
@@ -61,7 +66,7 @@ class GoogleApiKeySettingsPanel {
 
     static void register(MontoyaApi api) {
         try {
-            GoogleApiKeySettingsPanel settingsPanel = new GoogleApiKeySettingsPanel(api);
+            ExtensionSettingsPanel settingsPanel = new ExtensionSettingsPanel(api);
             Object proxy = java.lang.reflect.Proxy.newProxyInstance(
                     api.getClass().getClassLoader(),
                     new Class[]{Class.forName("burp.api.montoya.ui.settings.SettingsPanel")},
@@ -70,7 +75,7 @@ class GoogleApiKeySettingsPanel {
                             return settingsPanel.panel;
                         }
                         if ("keywords".equals(method.getName())) {
-                            return java.util.Set.of("google", "api", "key", "gemini");
+                            return java.util.Set.of("activescan", "active", "scan", "google", "api", "key", "gemini");
                         }
                         return null;
                     }

--- a/src/burp/GoogleApiKeyScan.java
+++ b/src/burp/GoogleApiKeyScan.java
@@ -26,7 +26,7 @@ public class GoogleApiKeyScan extends ParamScan {
             "to automatically check whether this key grants Gemini API access.</i></p>";
 
     private static final String UPGRADE_TIP =
-            "<p><i>Tip: Update Burp Suite to 2025.5+ to enable the Gemini API key " +
+            "<p><i>Tip: Update Burp Suite to 2025.6+ to enable the Gemini API key " +
             "verification setting.</i></p>";
 
     private static final String INFO_DETAIL_VERIFIED =

--- a/src/burp/GoogleApiKeyScan.java
+++ b/src/burp/GoogleApiKeyScan.java
@@ -83,7 +83,8 @@ public class GoogleApiKeyScan extends ParamScan {
             return Collections.emptyList();
         }
 
-        boolean shouldVerify = BurpExtender.verifyGeminiAccess.get();
+        boolean shouldVerify = ExtensionSettingsPanel.getVerifyGeminiAccess();
+        Utilities.callbacks.printOutput("shouldVerify: " + shouldVerify);
         List<IScanIssue> issues = new ArrayList<>();
         IHttpService httpService = basePair.getHttpService();
         java.net.URL url = Utilities.helpers.analyzeRequest(basePair).getUrl();

--- a/src/burp/GoogleApiKeyScan.java
+++ b/src/burp/GoogleApiKeyScan.java
@@ -1,0 +1,209 @@
+package burp;
+
+import burp.api.montoya.http.message.requests.HttpRequest;
+import burp.api.montoya.http.message.HttpRequestResponse;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class GoogleApiKeyScan extends ParamScan {
+
+    private static final Pattern API_KEY_PATTERN = Pattern.compile("AIza[0-9A-Za-z_-]{35}");
+    private static final String GEMINI_BASE = "https://generativelanguage.googleapis.com/v1beta/";
+
+    private static final String INFO_DETAIL =
+            "<p>A Google API key (<code>AIza...</code>) was found in the response. " +
+            "If the Generative Language API is enabled on the same GCP project and the key is unrestricted, " +
+            "it may grant access to Gemini endpoints.</p>" +
+            "<p><b>Remediation:</b> Audit key restrictions under " +
+            "<b>APIs &amp; Services &gt; Credentials</b> in the GCP Console.</p>";
+
+    private static final String GEMINI_DETAIL_PREFIX =
+            "<p>A Google API key was found and <b>verified to grant Gemini API access</b> " +
+            "(CWE-1188, CWE-269). Unrestricted keys silently inherit access to Gemini " +
+            "when the Generative Language API is enabled on the project.</p>";
+
+    private static final String GEMINI_DATA_EXPOSURE =
+            "<p><b>Impact:</b> An attacker may access uploaded files and cached context via " +
+            "<code>/files/</code> and <code>/cachedContents/</code>, run up billing costs, " +
+            "and exhaust API quotas.</p>";
+
+    private static final String REMEDIATION =
+            "<p><b>Remediation:</b> Rotate this key and restrict it to required APIs only under " +
+            "<b>APIs &amp; Services &gt; Credentials</b>. Use separate GCP projects for " +
+            "public-facing keys and sensitive APIs.</p>";
+
+    private enum GeminiEndpoint {
+        MODELS("models", "List models"),
+        FILES("files", "Access uploaded files and datasets"),
+        CACHED_CONTENTS("cachedContents", "Access cached context and documents");
+
+        final String path;
+        final String description;
+
+        GeminiEndpoint(String path, String description) {
+            this.path = path;
+            this.description = description;
+        }
+    }
+
+    private final ConcurrentHashMap<String, EnumSet<GeminiEndpoint>> verifiedKeys = new ConcurrentHashMap<>();
+
+    GoogleApiKeyScan(String name) {
+        super(name);
+    }
+
+    @Override
+    public List<IScanIssue> doPassiveScan(IHttpRequestResponse basePair) {
+        byte[] responseBytes = basePair.getResponse();
+        if (responseBytes == null) {
+            return Collections.emptyList();
+        }
+
+        String response = Utilities.helpers.bytesToString(responseBytes);
+        Set<String> uniqueKeys = extractUniqueKeys(response);
+        if (uniqueKeys.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<IScanIssue> issues = new ArrayList<>();
+        IHttpService httpService = basePair.getHttpService();
+        java.net.URL url = Utilities.helpers.analyzeRequest(basePair).getUrl();
+
+        for (String apiKey : uniqueKeys) {
+            IHttpRequestResponse markedPair = applyResponseMarker(basePair, response, apiKey);
+            IHttpRequestResponse[] evidence = new IHttpRequestResponse[]{markedPair};
+            String redactedKey = redactKey(apiKey);
+
+            if (Utilities.unloaded.get()) {
+                break;
+            }
+
+            EnumSet<GeminiEndpoint> accessible = getAccessibleEndpoints(apiKey);
+            if (!accessible.isEmpty()) {
+                boolean hasDataExposure = accessible.contains(GeminiEndpoint.FILES)
+                        || accessible.contains(GeminiEndpoint.CACHED_CONTENTS);
+
+                issues.add(new CustomScanIssue(
+                        httpService, url, evidence,
+                        hasDataExposure
+                                ? "Google API Key with Gemini API Access (Data Exposure)"
+                                : "Google API Key with Gemini API Access",
+                        buildGeminiDetail(redactedKey, accessible, hasDataExposure),
+                        "Certain",
+                        hasDataExposure
+                                ? CustomScanIssue.severity.High
+                                : CustomScanIssue.severity.Medium
+                ));
+            } else {
+                issues.add(new CustomScanIssue(
+                        httpService, url, evidence,
+                        "Google API Key Detected",
+                        INFO_DETAIL + "<p>Key found: <code>" + redactedKey + "</code></p>",
+                        "Certain", CustomScanIssue.severity.Information
+                ));
+            }
+        }
+
+        return issues;
+    }
+
+    @Override
+    public List<IScanIssue> doActiveScan(IHttpRequestResponse basePair, IScannerInsertionPoint insertionPoint) {
+        return Collections.emptyList();
+    }
+
+    private Set<String> extractUniqueKeys(String response) {
+        Set<String> keys = new HashSet<>();
+        Matcher matcher = API_KEY_PATTERN.matcher(response);
+        while (matcher.find()) {
+            keys.add(matcher.group());
+        }
+        return keys;
+    }
+
+    private EnumSet<GeminiEndpoint> getAccessibleEndpoints(String apiKey) {
+        EnumSet<GeminiEndpoint> cached = verifiedKeys.get(apiKey);
+        if (cached != null) {
+            return cached;
+        }
+        EnumSet<GeminiEndpoint> result = probeAllEndpoints(apiKey);
+        if (result != null) {
+            verifiedKeys.put(apiKey, result);
+        }
+        return result != null ? result : EnumSet.noneOf(GeminiEndpoint.class);
+    }
+
+    private EnumSet<GeminiEndpoint> probeAllEndpoints(String apiKey) {
+        EnumSet<GeminiEndpoint> accessible = EnumSet.noneOf(GeminiEndpoint.class);
+        boolean receivedDefinitiveResponse = false;
+
+        for (GeminiEndpoint endpoint : GeminiEndpoint.values()) {
+            if (Utilities.unloaded.get()) {
+                return null;
+            }
+            Boolean result = probeEndpoint(apiKey, endpoint);
+            if (result == null) {
+                continue;
+            }
+            receivedDefinitiveResponse = true;
+            if (result) {
+                accessible.add(endpoint);
+            }
+        }
+
+        return receivedDefinitiveResponse ? accessible : null;
+    }
+
+    private Boolean probeEndpoint(String apiKey, GeminiEndpoint endpoint) {
+        try {
+            HttpRequest request = HttpRequest.httpRequestFromUrl(
+                    GEMINI_BASE + endpoint.path + "?key=" + apiKey);
+            HttpRequestResponse response = Utilities.montoyaApi.http().sendRequest(request);
+            if (response.response() == null) {
+                return null;
+            }
+            return response.response().statusCode() == 200;
+        } catch (Exception e) {
+            Utilities.err("Failed to verify Gemini " + endpoint.path + " access: " + e.getMessage());
+            return null;
+        }
+    }
+
+    private String buildGeminiDetail(String redactedKey, EnumSet<GeminiEndpoint> accessible, boolean hasDataExposure) {
+        StringBuilder detail = new StringBuilder();
+        detail.append(GEMINI_DETAIL_PREFIX);
+
+        detail.append("<p><b>Accessible endpoints:</b></p><ul>");
+        for (GeminiEndpoint endpoint : accessible) {
+            detail.append("<li><code>/v1beta/").append(endpoint.path)
+                    .append("/</code> &mdash; ").append(endpoint.description).append("</li>");
+        }
+        detail.append("</ul>");
+
+        if (hasDataExposure) {
+            detail.append(GEMINI_DATA_EXPOSURE);
+        }
+
+        detail.append(REMEDIATION);
+        detail.append("<p>Key found: <code>").append(redactedKey).append("</code></p>");
+        return detail.toString();
+    }
+
+    private String redactKey(String apiKey) {
+        return apiKey.substring(0, 8) + "..." + apiKey.substring(apiKey.length() - 4);
+    }
+
+    private IHttpRequestResponse applyResponseMarker(IHttpRequestResponse basePair, String response, String apiKey) {
+        int keyStart = response.indexOf(apiKey);
+        if (keyStart < 0) {
+            return basePair;
+        }
+        List<int[]> responseMarkers = Collections.singletonList(
+                new int[]{keyStart, keyStart + apiKey.length()}
+        );
+        return Utilities.callbacks.applyMarkers(basePair, null, responseMarkers);
+    }
+}

--- a/src/burp/GoogleApiKeyScan.java
+++ b/src/burp/GoogleApiKeyScan.java
@@ -84,7 +84,6 @@ public class GoogleApiKeyScan extends ParamScan {
         }
 
         boolean shouldVerify = ExtensionSettingsPanel.getVerifyGeminiAccess();
-        Utilities.callbacks.printOutput("shouldVerify: " + shouldVerify);
         List<IScanIssue> issues = new ArrayList<>();
         IHttpService httpService = basePair.getHttpService();
         java.net.URL url = Utilities.helpers.analyzeRequest(basePair).getUrl();

--- a/src/burp/GoogleApiKeyScan.java
+++ b/src/burp/GoogleApiKeyScan.java
@@ -1,5 +1,6 @@
 package burp;
 
+import burp.api.montoya.http.RequestOptions;
 import burp.api.montoya.http.message.requests.HttpRequest;
 import burp.api.montoya.http.message.HttpRequestResponse;
 
@@ -10,13 +11,27 @@ import java.util.regex.Pattern;
 
 public class GoogleApiKeyScan extends ParamScan {
 
-    private static final Pattern API_KEY_PATTERN = Pattern.compile("AIza[0-9A-Za-z_-]{35}");
+    private static final Pattern API_KEY_PATTERN = Pattern.compile("AIza[0-9A-Za-z_-]{35}\\b");
     private static final String GEMINI_BASE = "https://generativelanguage.googleapis.com/v1beta/";
-
-    private static final String INFO_DETAIL =
+    private static final String INFO_DETAIL_BASE =
             "<p>A Google API key (<code>AIza...</code>) was found in the response. " +
             "If the Generative Language API is enabled on the same GCP project and the key is unrestricted, " +
             "it may grant access to Gemini endpoints.</p>" +
+            "<p><b>Remediation:</b> Audit key restrictions under " +
+            "<b>APIs &amp; Services &gt; Credentials</b> in the GCP Console.</p>";
+
+    private static final String VERIFY_TIP =
+            "<p><i>Tip: Enable <b>Verify Gemini API access</b> under " +
+            "Settings &gt; Extensions &gt; ActiveScan++ &gt; Google API Key Scan " +
+            "to automatically check whether this key grants Gemini API access.</i></p>";
+
+    private static final String UPGRADE_TIP =
+            "<p><i>Tip: Update Burp Suite to 2025.5+ to enable the Gemini API key " +
+            "verification setting.</i></p>";
+
+    private static final String INFO_DETAIL_VERIFIED =
+            "<p>A Google API key (<code>AIza...</code>) was found in the response. " +
+            "Verification was attempted and <b>no Gemini API access was confirmed</b>.</p>" +
             "<p><b>Remediation:</b> Audit key restrictions under " +
             "<b>APIs &amp; Services &gt; Credentials</b> in the GCP Console.</p>";
 
@@ -68,6 +83,7 @@ public class GoogleApiKeyScan extends ParamScan {
             return Collections.emptyList();
         }
 
+        boolean shouldVerify = BurpExtender.verifyGeminiAccess.get();
         List<IScanIssue> issues = new ArrayList<>();
         IHttpService httpService = basePair.getHttpService();
         java.net.URL url = Utilities.helpers.analyzeRequest(basePair).getUrl();
@@ -81,30 +97,41 @@ public class GoogleApiKeyScan extends ParamScan {
                 break;
             }
 
-            EnumSet<GeminiEndpoint> accessible = getAccessibleEndpoints(apiKey);
-            if (!accessible.isEmpty()) {
-                boolean hasDataExposure = accessible.contains(GeminiEndpoint.FILES)
-                        || accessible.contains(GeminiEndpoint.CACHED_CONTENTS);
+            if (shouldVerify) {
+                EnumSet<GeminiEndpoint> accessible = getAccessibleEndpoints(apiKey);
+                if (!accessible.isEmpty()) {
+                    boolean hasDataExposure = accessible.contains(GeminiEndpoint.FILES)
+                            || accessible.contains(GeminiEndpoint.CACHED_CONTENTS);
 
-                issues.add(new CustomScanIssue(
-                        httpService, url, evidence,
-                        hasDataExposure
-                                ? "Google API Key with Gemini API Access (Data Exposure)"
-                                : "Google API Key with Gemini API Access",
-                        buildGeminiDetail(redactedKey, accessible, hasDataExposure),
-                        "Certain",
-                        hasDataExposure
-                                ? CustomScanIssue.severity.High
-                                : CustomScanIssue.severity.Medium
-                ));
-            } else {
-                issues.add(new CustomScanIssue(
-                        httpService, url, evidence,
-                        "Google API Key Detected",
-                        INFO_DETAIL + "<p>Key found: <code>" + redactedKey + "</code></p>",
-                        "Certain", CustomScanIssue.severity.Information
-                ));
+                    issues.add(new CustomScanIssue(
+                            httpService, url, evidence,
+                            hasDataExposure
+                                    ? "Google API Key with Gemini API Access (Data Exposure)"
+                                    : "Google API Key with Gemini API Access",
+                            buildGeminiDetail(redactedKey, accessible, hasDataExposure),
+                            "Certain",
+                            hasDataExposure
+                                    ? CustomScanIssue.severity.High
+                                    : CustomScanIssue.severity.Medium
+                    ));
+                    continue;
+                }
             }
+
+            String infoDetail;
+            if (shouldVerify) {
+                infoDetail = INFO_DETAIL_VERIFIED;
+            } else if (BurpExtender.settingsPanelAvailable) {
+                infoDetail = INFO_DETAIL_BASE + VERIFY_TIP;
+            } else {
+                infoDetail = INFO_DETAIL_BASE + UPGRADE_TIP;
+            }
+            issues.add(new CustomScanIssue(
+                    httpService, url, evidence,
+                    "Google API Key Detected",
+                    infoDetail + "<p>Key found: <code>" + redactedKey + "</code></p>",
+                    "Certain", CustomScanIssue.severity.Information
+            ));
         }
 
         return issues;
@@ -161,7 +188,8 @@ public class GoogleApiKeyScan extends ParamScan {
         try {
             HttpRequest request = HttpRequest.httpRequestFromUrl(
                     GEMINI_BASE + endpoint.path + "?key=" + apiKey);
-            HttpRequestResponse response = Utilities.montoyaApi.http().sendRequest(request);
+            RequestOptions options = RequestOptions.requestOptions().withUpstreamTLSVerification();
+            HttpRequestResponse response = Utilities.montoyaApi.http().sendRequest(request, options);
             if (response.response() == null) {
                 return null;
             }

--- a/src/burp/GoogleApiKeyScan.java
+++ b/src/burp/GoogleApiKeyScan.java
@@ -121,7 +121,7 @@ public class GoogleApiKeyScan extends ParamScan {
             String infoDetail;
             if (shouldVerify) {
                 infoDetail = INFO_DETAIL_VERIFIED;
-            } else if (BurpExtender.settingsPanelAvailable) {
+            } else if (ExtensionSettingsPanel.isPanelAvailable()) {
                 infoDetail = INFO_DETAIL_BASE + VERIFY_TIP;
             } else {
                 infoDetail = INFO_DETAIL_BASE + UPGRADE_TIP;

--- a/src/burp/GoogleApiKeySettingsPanel.java
+++ b/src/burp/GoogleApiKeySettingsPanel.java
@@ -1,0 +1,86 @@
+package burp;
+
+import burp.api.montoya.MontoyaApi;
+
+import javax.swing.*;
+import java.awt.*;
+import java.lang.reflect.Method;
+
+class GoogleApiKeySettingsPanel {
+
+    private static final String PERSISTENCE_KEY = "google-api-key.verify-gemini-access";
+
+    private final JPanel panel;
+
+    GoogleApiKeySettingsPanel(MontoyaApi api) {
+        boolean savedValue = "true".equals(api.persistence().extensionData().getString(PERSISTENCE_KEY));
+        BurpExtender.verifyGeminiAccess.set(savedValue);
+
+        JCheckBox verifyCheckbox = new JCheckBox("Verify Gemini API access (sends requests to Google)");
+        verifyCheckbox.setIconTextGap(8);
+        verifyCheckbox.setSelected(savedValue);
+        verifyCheckbox.addActionListener(e -> {
+            boolean selected = verifyCheckbox.isSelected();
+            BurpExtender.verifyGeminiAccess.set(selected);
+            api.persistence().extensionData().setString(PERSISTENCE_KEY, String.valueOf(selected));
+        });
+
+        Font defaultFont = UIManager.getFont("Label.font");
+        if (defaultFont == null) {
+            defaultFont = new JLabel().getFont();
+        }
+        float defaultSize = defaultFont.getSize();
+
+        JLabel heading = new JLabel("Google API Key Scan");
+        heading.setFont(defaultFont.deriveFont(Font.BOLD, (int) (1.2f * defaultSize)));
+        heading.setAlignmentX(Component.LEFT_ALIGNMENT);
+        heading.setBorder(BorderFactory.createEmptyBorder(0, 0, 5, 0));
+
+        JTextArea description = new JTextArea(
+                "When enabled, detected API keys are checked against Google's Gemini API " +
+                "endpoints to confirm access. This upgrades findings from Information to " +
+                "Medium/High severity.");
+        description.setEditable(false);
+        description.setFocusable(false);
+        description.setLineWrap(true);
+        description.setWrapStyleWord(true);
+        description.setOpaque(false);
+        description.setFont(defaultFont);
+        description.setAlignmentX(Component.LEFT_ALIGNMENT);
+        description.setBorder(BorderFactory.createEmptyBorder(0, 0, 10, 0));
+
+        verifyCheckbox.setAlignmentX(Component.LEFT_ALIGNMENT);
+
+        panel = new JPanel();
+        panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
+        panel.setBorder(BorderFactory.createEmptyBorder(20, 20, 20, 20));
+        panel.add(heading);
+        panel.add(description);
+        panel.add(verifyCheckbox);
+    }
+
+    static void register(MontoyaApi api) {
+        try {
+            GoogleApiKeySettingsPanel settingsPanel = new GoogleApiKeySettingsPanel(api);
+            Object proxy = java.lang.reflect.Proxy.newProxyInstance(
+                    api.getClass().getClassLoader(),
+                    new Class[]{Class.forName("burp.api.montoya.ui.settings.SettingsPanel")},
+                    (p, method, args) -> {
+                        if ("uiComponent".equals(method.getName())) {
+                            return settingsPanel.panel;
+                        }
+                        if ("keywords".equals(method.getName())) {
+                            return java.util.Set.of("google", "api", "key", "gemini");
+                        }
+                        return null;
+                    }
+            );
+            Method registerMethod = api.userInterface().getClass().getMethod(
+                    "registerSettingsPanel", Class.forName("burp.api.montoya.ui.settings.SettingsPanel"));
+            registerMethod.invoke(api.userInterface(), proxy);
+            BurpExtender.settingsPanelAvailable = true;
+        } catch (Exception e) {
+            Utilities.err("Could not register settings panel (requires Burp 2025.5+): " + e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a new passive scan check (`GoogleApiKeyScan`) that detects Google API keys (`AIza...`) in HTTP responses
- Verifies whether discovered keys grant access to Gemini API endpoints (`/models`, `/files`, `/cachedContents`)
- Reports at the highest verified severity only: **High** (data exposure via `/files` or `/cachedContents`), **Medium** (models-only access), or **Information** (key found, no Gemini access)
- Caches verification results per key (skips transient failures to allow retry)
- Respects extension unload to stop external requests promptly

Based on the [TruffleHog disclosure](https://trufflesecurity.com/blog/anyone-can-access-deleted-and-private-repo-data-github) of CWE-1188 / CWE-269 — unrestricted Google API keys silently inherit Gemini API access when the Generative Language API is enabled on the same GCP project.

## Test plan

- [ ] Build with `./gradlew fatJar` and load JAR in Burp Suite
- [ ] Browse to a page containing an `AIza...` key through the proxy
- [ ] Verify appropriate issue severity appears in Scanner tab
- [ ] Confirm same key is not reported at multiple severity levels
- [ ] Confirm duplicate keys in the same response only generate one issue